### PR TITLE
fix: remove constant_score in autocomplete query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ docker-down:
 docker-logs:
 	@${DOCKER_COMPOSE} logs -f
 
+test:
+	@${DOCKER_COMPOSE} run --rm --entrypoint '' app npm run ci
+
 ## List all available commands
 help:
 	@printf "${COLOR_TITLE_BLOCK}${PROJECT} Makefile${COLOR_RESET}\n"

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -19,7 +19,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'ngram:analyzer': 'peliasQuery',
   'ngram:field': 'name.default',
-  'ngram:boost': 100,
+  'ngram:boost': 1,
   'ngram:cutoff_frequency': 0.01,
 
   'phrase:analyzer': 'peliasQuery',
@@ -62,6 +62,11 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'multi_match:ngrams_strict:type': 'phrase',
   'multi_match:first_tokens_only:type': 'phrase',
   'multi_match:boost_exact_matches:type': 'phrase',
+
+  // full text search
+  // 'multi_match:ngrams_strict:type': 'best_fields' // (default value in ES).
+  // 'multi_match:ngrams_strict:fuzziness': 'AUTO',
+  // 'multi_match:ngrams_strict:minimum_should_match': '2<90%',
 
   // setting 'cutoff_frequency' will result in very common
   // terms such as country not scoring at all

--- a/query/view/ngrams_last_token_only.js
+++ b/query/view/ngrams_last_token_only.js
@@ -26,9 +26,5 @@ module.exports = function( vs ){
   vsCopy.var('input:name').set( tokens.join(' ') );
 
   // return the view rendered using the copy
-  return {
-    'constant_score': {
-      'filter': ngrams_strict( vsCopy )
-    }
-  };
+  return ngrams_strict( vsCopy );
 };

--- a/query/view/ngrams_last_token_only_multi.js
+++ b/query/view/ngrams_last_token_only_multi.js
@@ -35,10 +35,6 @@ module.exports = function (adminFields){
     if( !rendered ){ return rendered; }
 
     // return the view rendered using the copy
-    return {
-      'constant_score': {
-        'filter': rendered
-      }
-    };
+    return rendered;
   };
 };

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'test',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'test',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should':[{

--- a/test/unit/fixture/autocomplete_boundary_gid.js
+++ b/test/unit/fixture/autocomplete_boundary_gid.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'test',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'test',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should':[{

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'test',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'test',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should':[{

--- a/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
@@ -3,17 +3,13 @@ module.exports = {
     'bool': {
       'must': [
         {
-          'constant_score': {
-            'filter': {
-              'multi_match': {
-                'fields': ['name.default', 'name.en'],
-                'analyzer': 'peliasQuery',
-                'query': 'test',
-                'boost': 100,
-                'type': 'phrase',
-                'slop': 3
-              }
-            }
+          'multi_match': {
+            'fields': ['name.default', 'name.en'],
+            'analyzer': 'peliasQuery',
+            'query': 'test',
+            'boost': 1,
+            'type': 'phrase',
+            'slop': 3
           }
         }
       ],

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'test',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'test',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should': [{

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'test',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'test',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should': [{

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -12,30 +12,26 @@ module.exports = {
         }
       },
       {
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': [
-                'parent.country.ngram^1',
-                'parent.dependency.ngram^1',
-                'parent.macroregion.ngram^1',
-                'parent.region.ngram^1',
-                'parent.county.ngram^1',
-                'parent.localadmin.ngram^1',
-                'parent.locality.ngram^1',
-                'parent.borough.ngram^1',
-                'parent.neighbourhood.ngram^1',
-                'parent.locality_a.ngram^1',
-                'parent.region_a.ngram^1',
-                'parent.country_a.ngram^1',
-                'name.default^1.5',
-                'name.en^1.5'
-              ],
-              'query': 'three',
-              'analyzer': 'peliasQuery',
-              'type': 'cross_fields'
-            }
-          }
+        'multi_match': {
+          'fields': [
+            'parent.country.ngram^1',
+            'parent.dependency.ngram^1',
+            'parent.macroregion.ngram^1',
+            'parent.region.ngram^1',
+            'parent.county.ngram^1',
+            'parent.localadmin.ngram^1',
+            'parent.locality.ngram^1',
+            'parent.borough.ngram^1',
+            'parent.neighbourhood.ngram^1',
+            'parent.locality_a.ngram^1',
+            'parent.region_a.ngram^1',
+            'parent.country_a.ngram^1',
+            'name.default^1.5',
+            'name.en^1.5'
+          ],
+          'query': 'three',
+          'analyzer': 'peliasQuery',
+          'type': 'cross_fields'
         }
       }],
       'should':[

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
@@ -12,17 +12,13 @@ module.exports = {
         }
       },
       {
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'three',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'three',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should': [

--- a/test/unit/fixture/autocomplete_linguistic_one_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_one_char_token.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 't',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 't',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should':[{

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'test',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'test',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should':[{

--- a/test/unit/fixture/autocomplete_linguistic_three_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_three_char_token.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'tes',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'tes',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should':[{

--- a/test/unit/fixture/autocomplete_linguistic_two_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_two_char_token.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'te',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'te',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should':[{

--- a/test/unit/fixture/autocomplete_with_category_filtering.js
+++ b/test/unit/fixture/autocomplete_with_category_filtering.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'test',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'test',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should': [{

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'test',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'test',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should':[{

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -2,17 +2,13 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'constant_score': {
-          'filter': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'query': 'test',
-              'boost': 100,
-              'type': 'phrase',
-              'slop': 3
-            }
-          }
+        'multi_match': {
+          'fields': ['name.default', 'name.en'],
+          'analyzer': 'peliasQuery',
+          'query': 'test',
+          'boost': 1,
+          'type': 'phrase',
+          'slop': 3
         }
       }],
       'should':[{


### PR DESCRIPTION
Search url : 
`/v1/autocomplete?text=Le Mont St Michel`

Query output : 
```
{
  "size": 20,
  "query": {
    "bool": {
      "must": [
        {
          "multi_match": {
            "query": "Le Mont",
            "fields": ["phrase.default^1.0", "phrase.en^1.0"],
            "type": "phrase",
            "operator": "OR",
            "analyzer": "peliasQuery",
            "slop": 3,
            "prefix_length": 0,
            "max_expansions": 50,
            "zero_terms_query": "NONE",
            "auto_generate_synonyms_phrase_query": true,
            "fuzzy_transpositions": true,
            "boost": 1.0
          }
        },
        {
          "multi_match": {
            "query": "St",
            "fields": ["name.default^1.0", "name.en^1.0"],
            "type": "phrase",
            "operator": "OR",
            "analyzer": "peliasQuery",
            "slop": 3,
            "prefix_length": 0,
            "max_expansions": 50,
            "zero_terms_query": "NONE",
            "auto_generate_synonyms_phrase_query": true,
            "fuzzy_transpositions": true,
            "boost": 1.0
          }
        },
        {
          "multi_match": {
            "query": "Michel",
            "fields": [
              "name.default^1.5",
              "name.en^1.5",
              "parent.borough.ngram^1.0",
              "parent.country.ngram^1.0",
              "parent.country_a.ngram^1.0",
              "parent.county.ngram^1.0",
              "parent.dependency.ngram^1.0",
              "parent.localadmin.ngram^1.0",
              "parent.locality.ngram^1.0",
              "parent.locality_a.ngram^1.0",
              "parent.macroregion.ngram^1.0",
              "parent.neighbourhood.ngram^1.0",
              "parent.region.ngram^1.0",
              "parent.region_a.ngram^1.0"
            ],
            "type": "cross_fields",
            "operator": "OR",
            "analyzer": "peliasAdmin",
            "slop": 0,
            "prefix_length": 0,
            "max_expansions": 50,
            "zero_terms_query": "NONE",
            "auto_generate_synonyms_phrase_query": true,
            "fuzzy_transpositions": true,
            "boost": 1.0
          }
        }
      ],
      "filter": [
        {
          "terms": {
            "layer": [
              "postalcode",
              "locality",
              "neighbourhood",
              "localadmin",
              "county",
              "macrohood",
              "macrocounty",
              "region",
              "borough",
              "macroregion",
              "country",
              "dependency",
              "venue"
            ],
            "boost": 1.0
          }
        }
      ],
      "should": [
        {
          "function_score": {
            "query": { "match_all": { "boost": 1.0 } },
            "functions": [
              {
                "filter": { "match_all": { "boost": 1.0 } },
                "weight": 1.0,
                "field_value_factor": {
                  "field": "popularity",
                  "factor": 1.0,
                  "missing": 1.0,
                  "modifier": "log1p"
                }
              }
            ],
            "score_mode": "first",
            "boost_mode": "replace",
            "max_boost": 20.0,
            "boost": 1.0
          }
        },
        {
          "function_score": {
            "query": { "match_all": { "boost": 1.0 } },
            "functions": [
              {
                "filter": { "match_all": { "boost": 1.0 } },
                "weight": 3.0,
                "field_value_factor": {
                  "field": "population",
                  "factor": 1.0,
                  "missing": 1.0,
                  "modifier": "log1p"
                }
              }
            ],
            "score_mode": "first",
            "boost_mode": "replace",
            "max_boost": 20.0,
            "boost": 1.0
          }
        },
        {
          "function_score": {
            "query": { "match_all": { "boost": 1.0 } },
            "functions": [
              {
                "filter": {
                  "match": {
                    "source": {
                      "query": "campings.com",
                      "operator": "OR",
                      "prefix_length": 0,
                      "max_expansions": 50,
                      "fuzzy_transpositions": true,
                      "lenient": false,
                      "zero_terms_query": "NONE",
                      "auto_generate_synonyms_phrase_query": true,
                      "boost": 1.0
                    }
                  }
                },
                "weight": 5.0
              },
              {
                "filter": {
                  "match": {
                    "source": {
                      "query": "whosonfirst",
                      "operator": "OR",
                      "prefix_length": 0,
                      "max_expansions": 50,
                      "fuzzy_transpositions": true,
                      "lenient": false,
                      "zero_terms_query": "NONE",
                      "auto_generate_synonyms_phrase_query": true,
                      "boost": 1.0
                    }
                  }
                },
                "weight": 3.0
              },
              {
                "filter": {
                  "match": {
                    "source": {
                      "query": "geonames",
                      "operator": "OR",
                      "prefix_length": 0,
                      "max_expansions": 50,
                      "fuzzy_transpositions": true,
                      "lenient": false,
                      "zero_terms_query": "NONE",
                      "auto_generate_synonyms_phrase_query": true,
                      "boost": 1.0
                    }
                  }
                },
                "weight": 1.0
              },
              {
                "filter": {
                  "match": {
                    "source": {
                      "query": "openstreetmap",
                      "operator": "OR",
                      "prefix_length": 0,
                      "max_expansions": 50,
                      "fuzzy_transpositions": true,
                      "lenient": false,
                      "zero_terms_query": "NONE",
                      "auto_generate_synonyms_phrase_query": true,
                      "boost": 1.0
                    }
                  }
                },
                "weight": 0.0
              }
            ],
            "score_mode": "sum",
            "boost_mode": "multiply",
            "max_boost": 50.0,
            "min_score": 1.0,
            "boost": 5.0
          }
        }
      ],
      "adjust_pure_negative": true,
      "boost": 1.0
    }
  },
  "sort": [{ "_score": { "order": "desc" } }],
  "track_scores": true
}
```